### PR TITLE
Part 2 - fix app config

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,6 +12,7 @@
       "contentResolver": "",
       "webResolver": ""
     },
+    "tapInheritance": [],
     "extensions": [],
     "aliases": {
       "nameSpace": "",

--- a/babel.config.js
+++ b/babel.config.js
@@ -82,10 +82,7 @@ const babelSetup = () => {
       extensions: EXTENSIONS,
       // Aliases work differently in webpack, so add the webResolver method helper for alias mapping
       resolvePath: isWeb && webResolver || undefined,
-      alias: {
-        ...buildAliases(),
-        ...aliases,
-      }
+      alias: buildAliases()
   }])
 
   return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tap-resolver",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Allows switching react-native taps quickly",
   "main": "babel.config.js",
   "author": "Lance Tipton",

--- a/post_install.js
+++ b/post_install.js
@@ -1,6 +1,8 @@
 const fs = require('fs')
 const path = require('path')
 const rootDir = path.join(__dirname)
+const appRoot = require('app-root-path').path
+const isRootPackage = appRoot.indexOf('/node_modules/') === -1
 
 /**
  * Sets up zr-rn-taps folder in node_modules ( temporary )
@@ -14,5 +16,17 @@ const setupRNTap = () => {
   rnTapFiles.map(file => !fs.existsSync(file) && fs.mkdirSync(file))
 }
 
+/**
+ * Make a temp directory to store tap config files
+ */
+const makeTempFolder = () => {
+  // Build the temp directory path
+  const tempDir = path.join(__dirname, './temp')
+  // make the directory if it doesn't exist
+  !fs.existsSync(tempDir) && fs.mkdirSync(tempDir)
+}
+
+makeTempFolder()
+
 // Ensure the external-test-taps folder exists
-setupRNTap()
+isRootPackage && setupRNTap()

--- a/src/__tests__/setupClient.js
+++ b/src/__tests__/setupClient.js
@@ -56,10 +56,10 @@ describe('Setup Tap', () => {
   })
 
   it('should indicate if a tap folder exists or not', () => {
-    const { HAS_CLIENT } = setupTap(testAppRoot, appJson, null)
-    expect(HAS_CLIENT).toBe(false)
+    const { HAS_TAP } = setupTap(testAppRoot, appJson, null)
+    expect(HAS_TAP).toBe(false)
 
-    const { HAS_CLIENT: tapDefined } = setupTap(testAppRoot, appJson, testTapName)
+    const { HAS_TAP: tapDefined } = setupTap(testAppRoot, appJson, testTapName)
     expect(tapDefined).toBe(true)
   })
 

--- a/src/buildAssets.js
+++ b/src/buildAssets.js
@@ -1,14 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 const { get, isStr } = require('jsutils')
-
-const assetExtensions = [
-  '.png',
-  '.jpg',
-  '.jpeg',
-  '.gif',
-  '.ttf',
-]
+const tapConstants = require('./tapConstants')
 
 /**
  * Gets all the asset files names from the passed in tapAssetPath
@@ -20,7 +13,7 @@ const assetExtensions = [
 const assetFileNames = (tapAssetPath, extensions=[]) => {
 
   // Get all allowed extensions
-  const allExtensions = assetExtensions.concat(extensions)
+  const allExtensions = get(tapConstants, [ 'extensions', 'assets' ], []).concat(extensions)
 
   // Create an Array from the assets found at the tapAssetPath
   return Array.from(

--- a/src/cacheInvalidator.js
+++ b/src/cacheInvalidator.js
@@ -1,19 +1,8 @@
 const path = require('path')
-
-const allFiles = [
-  './buildAliases',
-  './buildAssets',
-  './buildTapList',
-  './buildConstants',
-  './getAppConfig',
-  './contentResolver',
-  './setup',
-  './setupTap',
-  './webResolver',
-]
+const tapConstants = require('./tapConstants')
 
 module.exports = () => {
-  allFiles.map(file => {
+  tapConstants.cacheFiles.map(file => {
     delete require.cache[require.resolve(path.join(__dirname, file))]
   })
 }

--- a/src/getAppConfig.js
+++ b/src/getAppConfig.js
@@ -1,33 +1,79 @@
 const path = require('path')
 const { isObj, isEmpty, isStr, get } = require('jsutils')
 const { requireFile } = require('./helpers')
+const tapConstants = require('./tapConstants')
+
+const { configNames, configKeys }  = tapConstants
+
+/**
+ * Search's a number of paths in the applications root for tapResolver config
+ * @param {string} appRoot - Root directory of the mobile keg
+ * @param {boolean} validate - Should the found config object be validated
+ *
+ * @returns {Object} - Object with the tapResolver config if found
+ */
+const getAppConfig = (appRoot, validate=true) => (
+  configNames.reduce((foundConfig, file) => {
+
+    // If we already found the config just return it
+    if(foundConfig) return foundConfig
+
+    // Try to load the config file
+    const { data: config, location } = requireFile(appRoot, file)
+
+    // If config is not an object, just return
+    if(!isObj(config)) return foundConfig
+    
+    // Add the location and file name for future reference
+    config[configKeys.TAP_RESOLVER_LOC] = location
+    config[configKeys.TAP_RESOLVER_FILE] = file
+  
+    // If we're not validating, just return the config
+    // Otherwise check that it has the tapResolver key defined
+    // If it does return it, otherwise return foundConfig
+    return !validate
+      ? config
+      : config.tapResolver
+        ? config
+        : foundConfig
+
+  }, null)
+)
 
 /**
  * Gets the app config from app.json || package.json
  * Validates the paths of the app config
  * @param {string} appRoot - Root directory of the mobile keg
+ * @param {boolean} validate - Should the found config object be validated
  *
  * @returns {Object} app config object
  */
-module.exports = appRoot => {
+module.exports = (appRoot, validateObj=true, validatePaths=true) => {
 
   if(!isStr(appRoot))
     throw new Error(`Application root directory is required!`)
-
-  let appConfig = requireFile(appRoot, './app.json', false) || requireFile(appRoot, './package.json', true)
-
-  if(!isObj(appConfig) || isEmpty(appConfig))
-    throw new Error(`Could not find app.json in root directory!. app.json is required!`)
-
+  
+  // Get the app config from possible options
+  let appConfig = getAppConfig(appRoot, validateObj)
+  
+  if(validateObj && (!isObj(appConfig) || isEmpty(appConfig)))
+    throw new Error(
+      `Could not find config in ${configNames.join(', ')} from the applications root directory!`
+    )
+  
+  if(!validatePaths) return appConfig
+  
   const paths = get(appConfig, [ 'tapResolver', 'paths' ])
 
   if(!isObj(paths))
-    throw new Error(`App config does NOT define 'tapResolver.paths'. This path is required!`)
+    throw new Error(
+      `App config does NOT define 'tapResolver.paths'. The path key is required, and must be an object!`
+    )
 
   Array
     .from([ 'externalTaps', 'localTaps', 'baseTap' ])
     .map(path => {
-      if(!isStr(paths[path]))
+      if(!isStr(paths[path]) && paths[path] !== false)
         throw new Error(
           `Your app config 'tapResolver.paths' must contain a ${path} key as a string!`
         )

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const { get, isObj, isStr } = require('jsutils')
+const { get, isObj, isStr, keyMap, deepFreeze } = require('jsutils')
 
 /**
  * Checks is a path is a directory
@@ -58,6 +58,25 @@ const pathExistsSync = check => {
 }
 
 
+/**
+ * Ensures a directory exists
+ * @param {string} dirPath - path to ensure
+ *
+ * @return {string} - directory path that was ensured
+ */
+const ensureDirSync = dirPath => {
+  try {
+    // make the directory if it doesn't exist
+    !fs.existsSync(dirPath) && fs.mkdirSync(dirPath)
+
+    return dirPath
+  }
+  catch(err) {
+    return false
+  }
+}
+
+
 
 /**
  * Wraps require in a try catch to app doesn't throw when require is called inline
@@ -69,10 +88,15 @@ const pathExistsSync = check => {
  */
 const requireFile = (folder, file, logError) => {
   try {
-    return require(path.join(folder, file))
+    // Build the path to the file
+    const location = path.join(folder, file)
+    // load the data
+    const data = require(location)
+
+    return { data, location }
   }
   catch(e){
-    if(!logError) return
+    if(!logError) return {}
     logData(`Could not require file from path => ${path.join(folder, file)}`, `error`)
     logData(e.message, `error`)
     logData(e.stack, `error`)
@@ -95,6 +119,7 @@ const validateApp = (appRoot, appConfig) => {
 }
 
 module.exports = {
+  ensureDirSync,
   isDirectory,
   pathExists,
   pathExistsSync,

--- a/src/setup.js
+++ b/src/setup.js
@@ -23,23 +23,24 @@ module.exports = (appRoot, appConfig, contentResolver, tapName) => {
   
   const {
     ALIASES,
+    APP_CONFIG,
     APP_CONFIG_PATH,
     BASE_CONTENT,
     BASE_PATH,
     DYNAMIC_CONTENT,
     EXTENSIONS,
-    HAS_CLIENT
+    HAS_TAP
   } = buildConstants(appRoot, appConfig, tapName)
 
   const aliasesBuilder = buildAliases(
-    appConfig,
+    APP_CONFIG,
     contentResolver,
     { ...ALIASES },
     {
       base: BASE_CONTENT,
       basePath: BASE_PATH,
       dynamic: DYNAMIC_CONTENT,
-      tap: HAS_CLIENT,
+      tap: HAS_TAP,
       extensions: EXTENSIONS
     }
   )

--- a/src/tapConstants.js
+++ b/src/tapConstants.js
@@ -1,0 +1,59 @@
+const { keyMap, deepFreeze } = require('jsutils')
+
+/**
+ * Tap Resolver Constants
+ */
+module.exports = deepFreeze({
+  /**
+  * Locations where the tap resolver config could be located.
+  */
+  configNames: [
+    'tap.config.json',
+    'tap.json',
+    'app.json',
+    'package.json',
+  ],
+  /**
+  * Constants added to temp config files for reference
+  */
+  configKeys: keyMap([
+    'TAP_RESOLVER_LOC',
+    'TAP_RESOLVER_FILE',
+  ]),
+  /**
+  * Files that should have their cache cleared when cacheInvalidator is called
+  */
+  cacheFiles: [
+    './buildAliases',
+    './buildAssets',
+    './buildTapList',
+    './buildConstants',
+    './getAppConfig',
+    './contentResolver',
+    './setup',
+    './setupTap',
+    './webResolver',
+  ],
+  /**
+  * Files and asset extensions that can be resolved
+  */
+  extensions: {
+    assets: [
+      '.png',
+      '.jpg',
+      '.jpeg',
+      '.gif',
+      '.ttf',
+    ],
+    resolve: [
+      ".web.js",
+      ".native.js",
+      ".ios.js",
+      ".android.js",
+      ".js",
+      ".json",
+      ".sqlite",
+      ".ttf"
+    ]
+  }
+})


### PR DESCRIPTION
Part 2 of the client to tap updates. Continued converting `client` to `tap` and update the temp app config to now be properly used

**Tap Config and extentions updates**
* Updated some client refs to tap.
* Fixed tap config to properly join with root config.
* Added ability to use different file names for tap config.
* Created `tapConstanst` to hold defaults.
* Added temp path to paths in tap config to define how temp configs are built.
* Broke extentions an object for assets and resolve ( imported files )
* Added `.native.js` to resolve extentions