### PR TITLE
Part 3 - Rework tap assets

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,6 +3,7 @@
   "displayName": "Tap Resolver",
   "tapResolver": {
     "paths": {
+      "temp": "./temp",
       "baseTap": "",
       "tapAssets": "",
       "tapList": "",

--- a/src/__tests__/setupClient.js
+++ b/src/__tests__/setupClient.js
@@ -42,17 +42,17 @@ describe('Setup Tap', () => {
   })
 
   it('should provide the name of the tap from all sources (argument, node env, or appJson)', () => {
-    const { CLIENT_NAME } = setupTap(testAppRoot, appJson, testTapName)
-    expect(CLIENT_NAME).toBe(testTapName)
+    const { TAP_NAME } = setupTap(testAppRoot, appJson, testTapName)
+    expect(TAP_NAME).toBe(testTapName)
 
-    const { CLIENT_NAME: nameFromConfig } = setupTap(testAppRoot, appJson, null)
+    const { TAP_NAME: nameFromConfig } = setupTap(testAppRoot, appJson, null)
     expect(nameFromConfig).toBe(appJson.name)
 
     const envName = "Fight Milk Inc."
-    process.env.CLIENT = envName
-    const { CLIENT_NAME: nameFromNodeEnv } = setupTap(testAppRoot, appJson, null)
+    process.env.TAP = envName
+    const { TAP_NAME: nameFromNodeEnv } = setupTap(testAppRoot, appJson, null)
     expect(nameFromNodeEnv).toBe(envName)
-    delete process.env["CLIENT"]
+    delete process.env["TAP"]
   })
 
   it('should indicate if a tap folder exists or not', () => {

--- a/src/buildAssets.js
+++ b/src/buildAssets.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const path = require('path')
 const { get, isStr } = require('jsutils')
+const { isDirectory, ensureDirSync } = require('./helpers')
 const tapConstants = require('./tapConstants')
 
 /**
@@ -28,37 +29,71 @@ const assetFileNames = (tapAssetPath, extensions=[]) => {
 }
 
 /**
- * Generates a tap image cache file, which allows loading tap specific images
+ * Gets the assets path defined in the app config, or from the base path
+ * @param {Object} appConfig - app.json config file
  * @param {*} BASE_PATH - base directory of the app components
- * @param {*} TAP_NAME - name of the tap folder where the assets exist
  * @param {*} TAP_PATH - path to the taps folder
  *
- * @returns {Object} - path to taps assets
+ * @returns {string} - path to the assets folder
  */
-module.exports = (appConf, BASE_PATH, TAP_PATH, extensions) => {
+const getAssetsPath = (appConf, BASE_PATH, TAP_PATH) => {
+  const { assetsPath } = tapConstants
+  // Build the default assets path, and ensure it exists
+  const defAssetsPath = path.join(BASE_PATH, assetsPath)
+  ensureDirSync(defAssetsPath)
 
   // Get the tap assets defined path from the app config
   const tapAssets = get(appConf, [ 'tapResolver', 'paths', 'tapAssets' ])
 
-  // Check the tap assets, if none, use the base assets
-  const tapAssetPath = !tapAssets || !isStr(tapAssets)
-    ? path.join(BASE_PATH, 'assets')
-    : path.join(TAP_PATH, tapAssets)
+  // Build the path relative to the tap
+  const checkTapAssetPath = isStr(tapAssets) && path.join(TAP_PATH, tapAssets)
+  
+  // Check that the path exists, and is a directory
+  return checkTapAssetPath && isDirectory(checkTapAssetPath, true)
+    ? { full: checkTapAssetPath, relative: tapAssets }
+    : { full: defAssetsPath, relative: assetsPath }
+}
+
+/**
+ * Generates a tap image cache file, which allows loading tap specific images
+ * @param {Object} appConfig - app.json config file
+ * @param {*} BASE_PATH - base directory of the app components
+ * @param {*} TAP_PATH - path to the taps folder
+ *
+ * @returns {Object} - path to taps assets
+ */
+module.exports = (appConf, BASE_PATH, TAP_PATH) => {
+  
+  // Get the assets path
+  const { full: tapAssetPath, relative } = getAssetsPath(appConf, BASE_PATH, TAP_PATH)
 
   // Gets all the images assets in the taps assets folder
-  let properties = assetFileNames(tapAssetPath, extensions)
-    .map(name => `${name.split('.').shift()}: require('${tapAssetPath}/${name}')`)
-    .join(',\n  ')
-
+  const assetNames = []
+  let properties = assetFileNames(
+    tapAssetPath,
+    get(appConf, [ 'tapResolver', 'extensions', 'assets' ], [])
+  )
+    .map(name => {
+      // Get the asset name, and add it to the assetNames array
+      const assetName = name.split('.').shift()
+      // Add to the asset names with space in front for formatting
+      assetNames.push(`  ${assetName}`)
+      
+      // Return the require statement
+      return `const ${assetName} = require('${tapAssetPath}/${name}')`
+    })
+    .join(',\n')
+  
+  const exportStr = `${properties}\n\nexport {\n${assetNames}\n}`
   // Ass the assets content to the assets object
-  const string = `const assets = {\n  ${properties}\n}\n\nexport default assets`
+  // const string = `const assets = {\n  ${properties}\n}\n\nexport assets`
 
   // Build the location to save the assets
   const assetsPath = `${tapAssetPath}/index.js`
  
   // Write the file to the assets location
-  fs.writeFileSync(assetsPath, string, 'utf8')
+  fs.writeFileSync(assetsPath, exportStr, 'utf8')
 
-  // Return the path of the new assets file
-  return assetsPath
+  // Return the relative path so it can work with the aliases which are also relative
+  return relative
 }

--- a/src/buildAssets.js
+++ b/src/buildAssets.js
@@ -30,12 +30,12 @@ const assetFileNames = (tapAssetPath, extensions=[]) => {
 /**
  * Generates a tap image cache file, which allows loading tap specific images
  * @param {*} BASE_PATH - base directory of the app components
- * @param {*} CLIENT_NAME - name of the tap folder where the assets exist
- * @param {*} CLIENT_PATH - path to the taps folder
+ * @param {*} TAP_NAME - name of the tap folder where the assets exist
+ * @param {*} TAP_PATH - path to the taps folder
  *
  * @returns {Object} - path to taps assets
  */
-module.exports = (appConf, BASE_PATH, CLIENT_PATH, extensions) => {
+module.exports = (appConf, BASE_PATH, TAP_PATH, extensions) => {
 
   // Get the tap assets defined path from the app config
   const tapAssets = get(appConf, [ 'tapResolver', 'paths', 'tapAssets' ])
@@ -43,7 +43,7 @@ module.exports = (appConf, BASE_PATH, CLIENT_PATH, extensions) => {
   // Check the tap assets, if none, use the base assets
   const tapAssetPath = !tapAssets || !isStr(tapAssets)
     ? path.join(BASE_PATH, 'assets')
-    : path.join(CLIENT_PATH, tapAssets)
+    : path.join(TAP_PATH, tapAssets)
 
   // Gets all the images assets in the taps assets folder
   let properties = assetFileNames(tapAssetPath, extensions)

--- a/src/buildConstants.js
+++ b/src/buildConstants.js
@@ -69,10 +69,10 @@ const addNameSpace = (appConfig, addTo) => {
  * @returns {Object} - all dynamically mapped paths
  */
 const buildDynamicContent = (appConfig={}) => {
-
+  // Build the dynamic alias paths
   return freezeObj(
     addNameSpace(appConfig, {
-      ...get(appConfig, [ 'tapResolver', 'aliases', 'dynamic'], {})
+      ...get(appConfig, [ 'tapResolver', 'aliases', 'dynamic'], {}),
     })
   )
 }
@@ -132,12 +132,7 @@ module.exports = (appRoot, appConfig, tapName) => {
   } = setupTap(appRoot, appConfig, tapName)
 
   // Build the assets for the tap
-  const ASSETS_PATH = buildAssets(
-    APP_CONFIG,
-    BASE_PATH,
-    TAP_PATH,
-    get(APP_CONFIG, [ 'tapResolver', 'extensions', 'assets' ], [])
-  )
+  const ASSETS_PATH = buildAssets(APP_CONFIG, BASE_PATH, TAP_PATH)
 
   // Build the aliasPaths object from the built tap data
   const aliasPaths = {

--- a/src/buildConstants.js
+++ b/src/buildConstants.js
@@ -126,8 +126,8 @@ module.exports = (appRoot, appConfig, tapName) => {
     APP_CONFIG,
     APP_CONFIG_PATH,
     BASE_PATH,
-    CLIENT_NAME,
-    CLIENT_PATH,
+    TAP_NAME,
+    TAP_PATH,
     HAS_TAP,
   } = setupTap(appRoot, appConfig, tapName)
 
@@ -135,7 +135,7 @@ module.exports = (appRoot, appConfig, tapName) => {
   const ASSETS_PATH = buildAssets(
     APP_CONFIG,
     BASE_PATH,
-    CLIENT_PATH,
+    TAP_PATH,
     get(APP_CONFIG, [ 'tapResolver', 'extensions', 'assets' ], [])
   )
 
@@ -143,7 +143,7 @@ module.exports = (appRoot, appConfig, tapName) => {
   const aliasPaths = {
     assets: ASSETS_PATH,
     base: BASE_PATH,
-    tap: CLIENT_PATH,
+    tap: TAP_PATH,
     config: APP_CONFIG_PATH
   }
 
@@ -153,8 +153,8 @@ module.exports = (appRoot, appConfig, tapName) => {
     APP_CONFIG_PATH,
     BASE_PATH,
     ASSETS_PATH,
-    CLIENT_NAME,
-    CLIENT_PATH,
+    TAP_NAME,
+    TAP_PATH,
     HAS_TAP,
     ALIASES: buildAliases(appRoot, APP_CONFIG, aliasPaths),
     BASE_CONTENT: buildBaseContent(APP_CONFIG),

--- a/src/contentResolver.js
+++ b/src/contentResolver.js
@@ -47,7 +47,7 @@ module.exports = (appConfig, aliasMap, content, type) => {
     // Check if 'index' should be added to the file path
     // This allows loading the index.js of a folder
     const fullPath = checkAddIndex(
-      // Build the patth based on the tap alias
+      // Build the path based on the tap alias
       // Example: root_dir/taps/:tap_name/:type/:file_name
       // - w/o extension
       path.join(aliasMap[ `${nameSpace}Tap` ], type, match[1])

--- a/src/setupTap.js
+++ b/src/setupTap.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const rimraf = require('rimraf')
 const { deepMerge, logData, setLogs, isStr, isObj, get } = require('jsutils')
 const getAppConfig = require('./getAppConfig')
-const { validateApp, ensureDirSync } = require('./helpers')
+const { validateApp, ensureDirSync, isDirectory } = require('./helpers')
 const tapConstants = require('./tapConstants')
 const { configNames, configKeys }  = tapConstants
 
@@ -19,10 +19,22 @@ ensureDirSync(TEMP_DEF_FOLDER)
  * @returns {string} - path to the base tap
  */
 const getBaseTapPath = (appRoot, appConfig) => {
+
+  // Get the base tap path
   const { baseTap } = get(appConfig, [ 'tapResolver', 'paths' ], {})
-  return baseTap
-    ? path.join(appRoot, baseTap)
-    : path.join(appRoot, `/taps/`, appConfig.name)
+  
+  // Helper method to check for a directory
+  const checkBaseTap = check => isDirectory(check, true) && check
+  
+  // Check for the base tap from the app config
+  return checkBaseTap(path.join(appRoot, baseTap)) ||
+    // Check for a taps folder with the app config name
+    checkBaseTap(path.join(appRoot, '/taps', appConfig.name)) ||
+    // Check for a folder with the app config name
+    checkBaseTap(path.join(appRoot, appConfig.name)) ||
+    // If none of the above, just return the root
+    appRoot
+
 }
 
 /**

--- a/src/tapConstants.js
+++ b/src/tapConstants.js
@@ -34,6 +34,12 @@ module.exports = deepFreeze({
     './setupTap',
     './webResolver',
   ],
+  
+  /**
+  * Default assets path, relative to the base path of the app config
+  */
+  assetsPath: 'assets',
+  
   /**
   * Files and asset extensions that can be resolved
   */


### PR DESCRIPTION
Part 3 - Updated more `client`  refs to `tap` and refactored how assets file is built. Got rid of the default export. Now exports all images separately.
  * It now allows you to write =>
    ```
     import { myAsset } from 'SVAssets'
    ```
* where before you had to write  =>
    ```
    import myAssets from 'SVAssets'
    const { myAsset  } = myAssets
    ```

**Updates**
* Updated all CLIENT refs to be TAP
* Reworked assets building.
* Updated how the base tap is found
  * Gave it more locations to find the base tap